### PR TITLE
Add/remove "status: claimed" label appropriately

### DIFF
--- a/bin/server.py
+++ b/bin/server.py
@@ -25,6 +25,7 @@ webhook.register("issues", NewIssueLabelHook(
     whitelist=app.config["labels.whitelist"],
     aliases=app.config["labels.aliases"][0]
 ))
+webhook.register("issues", AssignedLabelHook())
 webhook.register("pull_request", NewPrLabelHook(
     whitelist=app.config["labels.whitelist"],
     aliases=app.config["labels.aliases"][0]

--- a/ghi_assist/hooks/assigned_label_hook.py
+++ b/ghi_assist/hooks/assigned_label_hook.py
@@ -1,0 +1,43 @@
+from .hook import Hook
+from ..utils import filter_by_claimed
+
+
+class AssignedLabelHook(Hook):
+    """
+    Hook to add or remove a the claimed label after (un)assignmhent.
+    """
+
+    def __init__(self):
+        self.labels = None
+        super(AssignedLabelHook, self).__init__()
+
+    def should_perform_action(self, payload, api=None):
+        """
+        Check whether we need to add or remove the label.
+        """
+        try:
+            action = payload["action"]
+            labels = payload["issue"]["labels"]
+        except KeyError, err:
+            print err
+            return False
+
+        if action == "assigned":
+            self.labels, updated_status = filter_by_claimed(labels, True)
+        elif action == "unassigned":
+            self.labels, updated_status = filter_by_claimed(labels, False)
+        else:
+            updated_status = False
+
+        return updated_status
+
+    def actions(self, payload, api):
+        """
+        Return the singleton list of actions to perform.
+
+        There is only one action necessary here: replace the old labels with
+        the new ones.
+        """
+        return [{"action": api.replace_labels,
+                 "args": {"labels": self.labels,
+                          "issue_url": payload["issue"]["url"]}}]

--- a/tests/test_assigned_labels.py
+++ b/tests/test_assigned_labels.py
@@ -1,0 +1,47 @@
+from ghi_assist.hooks.assigned_label_hook import AssignedLabelHook
+
+def test_assign():
+    """Test successful assignment."""
+    hook = AssignedLabelHook()
+    payload = {"action": "assigned",
+               "issue": {"labels": [{"name": "alpha"},
+                                    {"name": "beta"},
+                                    {"name": "gamma"}]}}
+    assert hook.should_perform_action(payload), "Need to perform action"
+    assert len(hook.labels) == 4, "Should be four labels"
+    assert "status: claimed" in hook.labels, "Needs to be claimed"
+
+def test_unassign():
+    """Test successful unassignment."""
+    hook = AssignedLabelHook()
+    payload = {"action": "unassigned",
+               "issue": {"labels": [{"name": "alpha"},
+                                    {"name": "beta"},
+                                    {"name": "gamma"},
+                                    {"name": "status: claimed"}]}}
+    assert hook.should_perform_action(payload), "Needs to perform action"
+    assert len(hook.labels) == 3, "Should be three labels"
+    assert "status: claimed" not in hook.labels, "Needs to be unclaimed"
+
+def test_unneeded_assign():
+    """Test unnecessary assignment."""
+    hook = AssignedLabelHook()
+    payload = {"action": "assigned",
+               "issue": {"labels": [{"name": "alpha"},
+                                    {"name": "beta"},
+                                    {"name": "gamma"},
+                                    {"name": "status: claimed"}]}}
+    assert not hook.should_perform_action(payload), "No need to perform action"
+    assert len(hook.labels) == 4, "Should be four labels"
+    assert "status: claimed" in hook.labels, "Needs to be claimed"
+
+def test_unneeded_unassign():
+    """Test unnecessary unassignment."""
+    hook = AssignedLabelHook()
+    payload = {"action": "unassigned",
+               "issue": {"labels": [{"name": "alpha"},
+                                    {"name": "beta"},
+                                    {"name": "gamma"}]}}
+    assert not hook.should_perform_action(payload), "No need to perform action"
+    assert len(hook.labels) == 3, "Should be three labels"
+    assert "status: claimed" not in hook.labels, "Needs to be unclaimed"


### PR DESCRIPTION
When an issue is assigned or unassigned, add or remove the "status:
claimed" label as appropriate.

Fixes dreamwidth/dw-free#1322.
